### PR TITLE
Map possible hardware acceleration devices into add-on

### DIFF
--- a/plex/config.yaml
+++ b/plex/config.yaml
@@ -16,6 +16,9 @@ map:
   - media:rw
   - share:rw
   - ssl
+devices:
+  - /dev/dri
+  - /dev/vchiq
 ports:
   1900/udp: 1900
   3005/tcp: 3005


### PR DESCRIPTION
# Proposed Changes

Maps `dri` and `vchiq` into the add-on container (if available).