### PR TITLE
Remove stale plexmediaserver.pid on startup

### DIFF
--- a/plex/rootfs/etc/s6-overlay/s6-rc.d/plex/run
+++ b/plex/rootfs/etc/s6-overlay/s6-rc.d/plex/run
@@ -12,5 +12,11 @@ export PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS=6
 export PLEX_MEDIA_SERVER_INFO_DEVICE="Hass.io"
 export PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR=/data
 
+# Check if "/data/Plex Media Server/plexmediaserver.pid" exists, if so remove it
+if bashio::fs.file_exists '/data/Plex Media Server/plexmediaserver.pid'; then
+    bashio::log.debug 'Removing stale PID file...'
+    rm -rf /data/Plex\ Media\ Server/plexmediaserver.pid
+fi
+
 # Run the Plex Media Server
 exec /usr/lib/plexmediaserver/Plex\ Media\ Server


### PR DESCRIPTION
# Proposed Changes

Check if `/data/Plex Media Server/plexmediaserver.pid` exists, if so remove it.
This prevented Plex from starting if the container was killed ungracefully.