### PR TITLE
⬆️ Upgrades Plex Media Server to 1.41.3.9292

### DIFF
--- a/plex/build.yaml
+++ b/plex/build.yaml
@@ -4,4 +4,4 @@ build_from:
   amd64: ghcr.io/hassio-addons/debian-base:7.5.1
   armv7: ghcr.io/hassio-addons/debian-base:7.5.1
 args:
-  release: 1.41.2.9200-c6bbc1b53
+  release: 1.41.3.9292-bc7397402


### PR DESCRIPTION
# Proposed Changes

> Upgrades Plex Media Server to 1.41.3.9292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to the latest release version: 1.41.3.9292-bc7397402.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->