### PR TITLE
⬆️ Upgrades Plex Media Server to 1.41.7.9799

### DIFF
--- a/plex/build.yaml
+++ b/plex/build.yaml
@@ -4,4 +4,4 @@ build_from:
   amd64: ghcr.io/hassio-addons/debian-base:7.8.1
   armv7: ghcr.io/hassio-addons/debian-base:7.8.1
 args:
-  release: 1.41.6.9685-d301f511a
+  release: 1.41.7.9799-5bce000f7


### PR DESCRIPTION
# Proposed Changes

Upgrades Plex Media Server to 1.41.7.9799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Plex addon build configuration to use the latest release version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->